### PR TITLE
Use getpass instead of os.getlogin, open url if not connected to serial

### DIFF
--- a/REVHubInterface/__main__.py
+++ b/REVHubInterface/__main__.py
@@ -10,13 +10,19 @@ import os
 import datetime
 import traceback
 import REVHubInterface.serialaccess as serialaccess
+import webbrowser
 # try:
 #     import ft232
 # except Exception as e: 
 #     print(platform.system)
 #     tkinter.messagebox.showerror('Drivers Not Detected', 'Please verify the correct drivers are installed.  Without the correct dirvers, firmware update functionality will be unavailable.\n\n - Windows 10 and above should automatically install the correct drivers when the Expansion Hub is plugged in.\n\n - Windows 7 requires a manual install. Please see this link for the correct driver (FTDI D2xx): https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip\n\n - On macOS, install libftdi via Homebrew: "brew install libftdi"\n\n - On Linux, install libftdi.  On Debian/Ubuntu-based systems, install it via "sudo apt install libftdi1"\n\nException Message:\n' + str(e))
 if not serialaccess.hasAccess(): 
-    tkinter.messagebox.showerror("User does not have serial access", "Your user does not have access to serial. Switch to a user that does, or add your user to a group that has serial access.\nhttps://github.com/unofficial-rev-port/REVHubInterface/blob/main/README.md#access-to-serial-on-linux")
+    result = tkinter.messagebox.showerror("User does not have serial access", "Your user does not have access to serial. Switch to a user that does, or add your user to a group that has serial access.\nPress OK to open a link with instructions.")
+    
+    if result == "ok":
+        webbrowser.open("https://github.com/unofficial-rev-port/REVHubInterface/blob/main/README.md#access-to-serial-on-linux")
+    exit(1)
+        
 
 def error(windowName: str, error: Exception) -> None:
     errName = str(error)

--- a/REVHubInterface/serialaccess.py
+++ b/REVHubInterface/serialaccess.py
@@ -1,10 +1,12 @@
 import grp
-import os, sys
+import getpass
+import sys
 
 def hasAccess():
     if sys.platform == "linux":
         try:
-            groups = [g.gr_name for g in grp.getgrall() if os.getlogin() in g.gr_mem]
+            user = getpass.getuser()  # Alternative to os.getlogin()
+            groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
             if 'dialout' in groups or 'uucp' in groups: return True
             return False
         except KeyError:


### PR DESCRIPTION
In serialaccess.py, os.getlogin was previously used to get the user instead of getpass.getuser(), which Python documentation lists as preferred over os.getlogin. os.getlogin() can fail in certain scenarios where getpass.getuser() does not, such as when using WSL.

If the user does not user have serial access, they are shown an error message with a URL in it. However, this URL is not able to be copied or clicked, meaning that the user must type it themselves. Instead, this PR changes it so that clicking the OK button will open the URL.